### PR TITLE
Request parsing improvements

### DIFF
--- a/fhirstarter/exceptions.py
+++ b/fhirstarter/exceptions.py
@@ -11,7 +11,7 @@ from fastapi import Request, status
 from fastapi.exceptions import HTTPException
 from fhir.resources.operationoutcome import OperationOutcome
 
-from .utils import make_operation_outcome
+from .utils import make_operation_outcome, parse_fhir_request
 
 
 class FHIRException(HTTPException, ABC):
@@ -104,15 +104,16 @@ class FHIRResourceNotFoundError(FHIRException):
 
     def operation_outcome(self) -> OperationOutcome:
         try:
-            _, resource_type_str, id_ = self._request.url.components.path.split("/")  # type: ignore
+            interaction_info = parse_fhir_request(self._request)
         except Exception as exception:
             raise AssertionError(
-                "Unable to get resource type and resource ID from request; request must be set"
+                "Unable to get resource type and resource ID from request; request must be set "
                 "before the response is created"
             ) from exception
         else:
             return make_operation_outcome(
                 "error",
                 "not-found",
-                f"Unknown {resource_type_str} resource '{id_}'",
+                f"Unknown {interaction_info.resource_type} resource "
+                f"'{interaction_info.resource_id}'",
             )

--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -49,6 +49,7 @@ from .utils import (
     create_route_args,
     format_response,
     make_operation_outcome,
+    parse_fhir_request,
     read_route_args,
     search_type_route_args,
     update_route_args,
@@ -558,8 +559,10 @@ async def _transform_search_type_post_request(
     is consumed when it parses the body to pass the values down to the handlers. Catching the
     request here allows for the body parameters to be merged with the query string parameters.
     """
+    interaction_info = parse_fhir_request(request)
+
     if (
-        request.url.path.endswith("/_search")
+        interaction_info.interaction_type == "search-type"
         and request.method == "POST"
         and request.headers.get("Content-Type") == "application/x-www-form-urlencoded"
     ):

--- a/fhirstarter/search_parameters.py
+++ b/fhirstarter/search_parameters.py
@@ -148,7 +148,7 @@ def search_parameter_sort_key(
     parameter_annotation: type | None = None,
 ) -> tuple[bool, bool, bool, bool, bool, str]:
     """
-    Return a sort key for a search paramter.
+    Return a sort key for a search parameter.
 
     This function allows for consistent sorting of search parameters throughout the package.
 

--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -8,28 +8,37 @@ from .utils import generate_fhir_resource_id, make_request
 
 
 @pytest.mark.parametrize(
-    argnames="request_,expected_result",
+    argnames="mount_path",
+    argvalues=["", "/subapi"],
+    ids=["without mount", "with mount"],
+)
+@pytest.mark.parametrize(
+    argnames="request_method,path,expected_result",
     argvalues=[
         (
-            make_request("GET", "/metadata"),
+            "GET",
+            "/metadata",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type="capabilities", resource_id=None
             ),
         ),
         (
-            make_request("POST", "/Patient"),
+            "POST",
+            "/Patient",
             InteractionInfo(  # type: ignore
                 resource_type="Patient", interaction_type="create", resource_id=None
             ),
         ),
         (
-            make_request("GET", f"/Patient/{(id_ := generate_fhir_resource_id())}"),
+            "GET",
+            f"/Patient/{(id_ := generate_fhir_resource_id())}",
             InteractionInfo(  # type: ignore
                 resource_type="Patient", interaction_type="read", resource_id=id_
             ),
         ),
         (
-            make_request("GET", "/Patient"),
+            "GET",
+            "/Patient",
             InteractionInfo(  # type: ignore
                 resource_type="Patient",
                 interaction_type="search-type",
@@ -37,7 +46,8 @@ from .utils import generate_fhir_resource_id, make_request
             ),
         ),
         (
-            make_request("POST", "/Patient/_search"),
+            "POST",
+            "/Patient/_search",
             InteractionInfo(  # type: ignore
                 resource_type="Patient",
                 interaction_type="search-type",
@@ -45,71 +55,71 @@ from .utils import generate_fhir_resource_id, make_request
             ),
         ),
         (
-            make_request("PUT", f"/Patient/{(id_ := generate_fhir_resource_id())}"),
+            "PUT",
+            f"/Patient/{(id_ := generate_fhir_resource_id())}",
             InteractionInfo(  # type: ignore
                 resource_type="Patient", interaction_type="update", resource_id=id_
             ),
         ),
         (
-            make_request(
-                "GET", f"/FakeResource/{(id_ := generate_fhir_resource_id())}"
-            ),
+            "GET",
+            f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request("GET", f"/FakeResource"),
+            "GET",
+            f"/FakeResource",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request(
-                "GET", f"/Patient/{(id_ := generate_fhir_resource_id())}/extra"
-            ),
+            "GET",
+            f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request("POST", "/FakeResource"),
+            "POST",
+            "/FakeResource",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request("POST", "/FakeResource/_search"),
+            "POST",
+            "/FakeResource/_search",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request("POST", "/FakeResource/extra"),
+            "POST",
+            "/FakeResource/extra",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request(
-                "PUT", f"/FakeResource/{(id_ := generate_fhir_resource_id())}"
-            ),
+            "PUT",
+            f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request(
-                "PUT", f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra"
-            ),
+            "PUT",
+            f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
         ),
         (
-            make_request(
-                "HEAD", f"/Patient/{(id_ := generate_fhir_resource_id())}/extra"
-            ),
+            "HEAD",
+            f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
             InteractionInfo(  # type: ignore
                 resource_type=None, interaction_type=None, resource_id=None
             ),
@@ -134,6 +144,9 @@ from .utils import generate_fhir_resource_id, make_request
     ],
 )
 def test_parse_fhir_request(
-    request_: Request, expected_result: InteractionInfo
+    mount_path: str, request_method: str, path: str, expected_result: InteractionInfo
 ) -> None:
-    assert parse_fhir_request(request_) == expected_result
+    assert (
+        parse_fhir_request(make_request(request_method, f"{mount_path}{path}"))
+        == expected_result
+    )

--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -1,0 +1,139 @@
+"""Test FHIR utils"""
+
+import pytest
+
+from .. import Request
+from ..utils import InteractionInfo, parse_fhir_request
+from .utils import generate_fhir_resource_id, make_request
+
+
+@pytest.mark.parametrize(
+    argnames="request_,expected_result",
+    argvalues=[
+        (
+            make_request("GET", "/metadata"),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type="capabilities", resource_id=None
+            ),
+        ),
+        (
+            make_request("POST", "/Patient"),
+            InteractionInfo(  # type: ignore
+                resource_type="Patient", interaction_type="create", resource_id=None
+            ),
+        ),
+        (
+            make_request("GET", f"/Patient/{(id_ := generate_fhir_resource_id())}"),
+            InteractionInfo(  # type: ignore
+                resource_type="Patient", interaction_type="read", resource_id=id_
+            ),
+        ),
+        (
+            make_request("GET", "/Patient"),
+            InteractionInfo(  # type: ignore
+                resource_type="Patient",
+                interaction_type="search-type",
+                resource_id=None,
+            ),
+        ),
+        (
+            make_request("POST", "/Patient/_search"),
+            InteractionInfo(  # type: ignore
+                resource_type="Patient",
+                interaction_type="search-type",
+                resource_id=None,
+            ),
+        ),
+        (
+            make_request("PUT", f"/Patient/{(id_ := generate_fhir_resource_id())}"),
+            InteractionInfo(  # type: ignore
+                resource_type="Patient", interaction_type="update", resource_id=id_
+            ),
+        ),
+        (
+            make_request(
+                "GET", f"/FakeResource/{(id_ := generate_fhir_resource_id())}"
+            ),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request("GET", f"/FakeResource"),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request(
+                "GET", f"/Patient/{(id_ := generate_fhir_resource_id())}/extra"
+            ),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request("POST", "/FakeResource"),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request("POST", "/FakeResource/_search"),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request("POST", "/FakeResource/extra"),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request(
+                "PUT", f"/FakeResource/{(id_ := generate_fhir_resource_id())}"
+            ),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request(
+                "PUT", f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra"
+            ),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+        (
+            make_request(
+                "HEAD", f"/Patient/{(id_ := generate_fhir_resource_id())}/extra"
+            ),
+            InteractionInfo(  # type: ignore
+                resource_type=None, interaction_type=None, resource_id=None
+            ),
+        ),
+    ],
+    ids=[
+        "capabilities",
+        "create",
+        "read",
+        "search-type",
+        "search-type post",
+        "update",
+        "read unrecognized resource type",
+        "search unrecognized resource type",
+        "unrecognized GET path",
+        "create unrecognized resource type",
+        "search POST unrecognized resource type",
+        "unrecognized POST path",
+        "update unrecognized resource type",
+        "unrecognized PUT path",
+        "unsupported HTTP method",
+    ],
+)
+def test_parse_fhir_request(
+    request_: Request, expected_result: InteractionInfo
+) -> None:
+    assert parse_fhir_request(request_) == expected_result

--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -12,138 +12,145 @@ from .utils import generate_fhir_resource_id, make_request
     ids=["without mount", "with mount"],
 )
 @pytest.mark.parametrize(
-    argnames="request_method,path,expected_result",
-    argvalues=[
-        (
-            "GET",
-            "/metadata",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type="capabilities", resource_id=None
+    argnames="_,request_method,path,expected_result",
+    argvalues=(
+        argvalues := [
+            (
+                "capabilitites",
+                "GET",
+                "/metadata",
+                InteractionInfo(  # type: ignore
+                    resource_type=None,
+                    interaction_type="capabilities",
+                    resource_id=None,
+                ),
             ),
-        ),
-        (
-            "POST",
-            "/Patient",
-            InteractionInfo(  # type: ignore
-                resource_type="Patient", interaction_type="create", resource_id=None
+            (
+                "create",
+                "POST",
+                "/Patient",
+                InteractionInfo(  # type: ignore
+                    resource_type="Patient", interaction_type="create", resource_id=None
+                ),
             ),
-        ),
-        (
-            "GET",
-            f"/Patient/{(id_ := generate_fhir_resource_id())}",
-            InteractionInfo(  # type: ignore
-                resource_type="Patient", interaction_type="read", resource_id=id_
+            (
+                "read",
+                "GET",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}",
+                InteractionInfo(  # type: ignore
+                    resource_type="Patient", interaction_type="read", resource_id=id_
+                ),
             ),
-        ),
-        (
-            "GET",
-            "/Patient",
-            InteractionInfo(  # type: ignore
-                resource_type="Patient",
-                interaction_type="search-type",
-                resource_id=None,
+            (
+                "search-type",
+                "GET",
+                "/Patient",
+                InteractionInfo(  # type: ignore
+                    resource_type="Patient",
+                    interaction_type="search-type",
+                    resource_id=None,
+                ),
             ),
-        ),
-        (
-            "POST",
-            "/Patient/_search",
-            InteractionInfo(  # type: ignore
-                resource_type="Patient",
-                interaction_type="search-type",
-                resource_id=None,
+            (
+                "search-type post",
+                "POST",
+                "/Patient/_search",
+                InteractionInfo(  # type: ignore
+                    resource_type="Patient",
+                    interaction_type="search-type",
+                    resource_id=None,
+                ),
             ),
-        ),
-        (
-            "PUT",
-            f"/Patient/{(id_ := generate_fhir_resource_id())}",
-            InteractionInfo(  # type: ignore
-                resource_type="Patient", interaction_type="update", resource_id=id_
+            (
+                "update",
+                "PUT",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}",
+                InteractionInfo(  # type: ignore
+                    resource_type="Patient", interaction_type="update", resource_id=id_
+                ),
             ),
-        ),
-        (
-            "GET",
-            f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "read unrecognized resource type",
+                "GET",
+                f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "GET",
-            f"/FakeResource",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "search unrecognized resource type",
+                "GET",
+                f"/FakeResource",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "GET",
-            f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "unrecognized GET path",
+                "GET",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "POST",
-            "/FakeResource",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "create unrecognized resource type",
+                "POST",
+                "/FakeResource",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "POST",
-            "/FakeResource/_search",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "search POST unrecognized resource type",
+                "POST",
+                "/FakeResource/_search",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "POST",
-            "/FakeResource/extra",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "unrecognized POST path",
+                "POST",
+                "/FakeResource/extra",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "PUT",
-            f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "update unrecognized resource type",
+                "PUT",
+                f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "PUT",
-            f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "unrecognized PUT path",
+                "PUT",
+                f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-        (
-            "HEAD",
-            f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
-            InteractionInfo(  # type: ignore
-                resource_type=None, interaction_type=None, resource_id=None
+            (
+                "unsupported HTTP method",
+                "HEAD",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
+                InteractionInfo(  # type: ignore
+                    resource_type=None, interaction_type=None, resource_id=None
+                ),
             ),
-        ),
-    ],
-    ids=[
-        "capabilities",
-        "create",
-        "read",
-        "search-type",
-        "search-type post",
-        "update",
-        "read unrecognized resource type",
-        "search unrecognized resource type",
-        "unrecognized GET path",
-        "create unrecognized resource type",
-        "search POST unrecognized resource type",
-        "unrecognized POST path",
-        "update unrecognized resource type",
-        "unrecognized PUT path",
-        "unsupported HTTP method",
-    ],
+        ]
+    ),
+    ids=[id_ for id_, *_ in argvalues],
 )
 def test_parse_fhir_request(
-    mount_path: str, request_method: str, path: str, expected_result: InteractionInfo
+    _: str,
+    mount_path: str,
+    request_method: str,
+    path: str,
+    expected_result: InteractionInfo,
 ) -> None:
     assert (
         parse_fhir_request(make_request(request_method, f"{mount_path}{path}"))

--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from .. import Request
 from ..utils import InteractionInfo, parse_fhir_request
 from .utils import generate_fhir_resource_id, make_request
 

--- a/fhirstarter/tests/utils.py
+++ b/fhirstarter/tests/utils.py
@@ -3,11 +3,14 @@
 import json
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from fhir.resources.fhirtypes import Id
 from funcy import omit
 from requests.models import Response
+
+from .. import Request
 
 _RESOURCE = {
     "resourceType": "Patient",
@@ -42,6 +45,33 @@ def id_from_create_response(response: Response) -> str:
 def json_dumps_pretty(value: Any) -> str:
     """Dump the value to JSON in pretty format."""
     return json.dumps(value, indent=2, separators=(", ", ": "))
+
+
+def make_request(
+    method: str,
+    path: str,
+) -> Request:
+    """Make a request for the purpose of testing."""
+    parsed_path = urlparse(path)
+
+    path = parsed_path.path
+    query_string = parsed_path.query
+
+    return Request(
+        scope={
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "path": path,
+            "raw_path": path.encode(),
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "headers": [],
+            "path_params": {},
+            "query_string": query_string,
+        }
+    )
 
 
 def assert_expected_response(

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -1,10 +1,9 @@
 """Utility functions for creation of routes and responses."""
 
 import logging
-import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
@@ -20,7 +19,9 @@ from .interactions import ResourceType, SearchTypeInteraction, TypeInteraction
 @dataclass
 class InteractionInfo:
     resource_type: str | None
-    interaction_type: str | None
+    interaction_type: Literal[
+        "create", "read", "update", "search-type", "capabilities"
+    ] | None
     resource_id: str | None
 
 
@@ -83,8 +84,6 @@ def parse_fhir_request(request: Request) -> InteractionInfo:
     if not split_path:
         return no_info
 
-    resource_type = None
-    interaction_type = None
     resource_id = None
 
     if request.method == "GET":

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for creation of routes and responses."""
 
+import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -31,13 +32,18 @@ def categorize_fhir_request(request: Request) -> InteractionInfo:
     Specifically, it will correctly categorize create, read, search-type, update, and capabilities
     interactions. Further enhancement is needed to support more cases.
     """
+    logging.warning(
+        "fhirstarter.utils.categorize_fhir_request has been deprecated and will be "
+        "removed in a future release"
+    )
+
     _, first_part, *rest = request.url.path.split("/")
 
     if request.method == "GET" and first_part == "metadata":
-        return InteractionInfo(resource_type=None, interaction_type="capabilities")  # type: ignore
+        return InteractionInfo(resource_type=None, interaction_type="capabilities", resource_id=None)  # type: ignore
 
     if not is_resource_type(first_part):
-        return InteractionInfo(resource_type=None, interaction_type=None)  # type: ignore
+        return InteractionInfo(resource_type=None, interaction_type=None, resource_id=None)  # type: ignore
 
     resource_type = first_part
     second_part = rest[0] if rest else None
@@ -58,7 +64,7 @@ def categorize_fhir_request(request: Request) -> InteractionInfo:
         case _:
             assert "Unexpected request format"
 
-    return InteractionInfo(resource_type, interaction_type)  # type: ignore
+    return InteractionInfo(resource_type, interaction_type, resource_id=id_)  # type: ignore
 
 
 def parse_fhir_request(request: Request) -> InteractionInfo:


### PR DESCRIPTION
* Centralize request parsing into a single function for consistency and testability
* BUGFIX: Correct the flawed assumption that request URLs can be parsed from head to tail; this doesn't work because of the potential use of mounted sub-applications. Request URLs are now parsed from tail to head instead.