### PR TITLE
Created a resources module to normalized how FHIR resources are imported

### DIFF
--- a/fhirstarter/__init__.py
+++ b/fhirstarter/__init__.py
@@ -1,9 +1,13 @@
+import importlib
+import os
+
+import fhir.resources
 from fastapi import Depends, Request, Response, status
 
 from .fhirstarter import FHIRStarter
 from .interactions import InteractionContext
 from .providers import FHIRProvider
-from .utils import categorize_fhir_request
+from .utils import categorize_fhir_request, parse_fhir_request
 
 __all__ = [
     "Depends",
@@ -13,5 +17,27 @@ __all__ = [
     "Request",
     "Response",
     "categorize_fhir_request",
+    "parse_fhir_request",
     "status",
 ]
+
+# Ensure that the specified FHIR sequence is supported by FHIRStarter
+FHIR_SEQUENCE = os.getenv("FHIR_SEQUENCE", "R5")
+SUPPORTED_FHIR_VERSIONS = ("STU3", "R4", "R4B", "R5")
+assert (
+    FHIR_SEQUENCE in SUPPORTED_FHIR_VERSIONS
+), f"FHIR sequence must be one of: {', '.join(SUPPORTED_FHIR_VERSIONS)}"
+
+# Ensure that a compatible version of fhir.resources is installed
+FHIR_RESOURCES_VERSION = importlib.metadata.version("fhir.resources")
+if FHIR_SEQUENCE == "R4":
+    assert (
+        FHIR_RESOURCES_VERSION == "6.5.0"
+    ), "fhir.resources package version must be 6.5.0 for FHIR R4 sequence"
+else:
+    assert (
+        FHIR_RESOURCES_VERSION >= "7.0.0"
+    ), "fhir.resources package version must be 7.0.0 or greater for FHIR STU3, R4B, and R5 sequences"
+    assert (
+        fhir.resources.__fhir_version__ == "5.0.0"
+    ), f"fhir.resources package references unexpected FHIR version {fhir.resources.__fhir_version__}"

--- a/fhirstarter/__init__.py
+++ b/fhirstarter/__init__.py
@@ -32,8 +32,8 @@ assert (
 FHIR_RESOURCES_VERSION = importlib.metadata.version("fhir.resources")
 if FHIR_SEQUENCE == "R4":
     assert (
-        FHIR_RESOURCES_VERSION == "6.5.0"
-    ), "fhir.resources package version must be 6.5.0 for FHIR R4 sequence"
+        FHIR_RESOURCES_VERSION == "6.4.0"
+    ), "fhir.resources package version must be 6.4.0 for FHIR R4 sequence"
 else:
     assert (
         FHIR_RESOURCES_VERSION >= "7.0.0"

--- a/fhirstarter/exceptions.py
+++ b/fhirstarter/exceptions.py
@@ -9,8 +9,8 @@ from abc import ABC, abstractmethod
 
 from fastapi import Request, status
 from fastapi.exceptions import HTTPException
-from fhir.resources.operationoutcome import OperationOutcome
 
+from .resources import OperationOutcome
 from .utils import make_operation_outcome, parse_fhir_request
 
 

--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -17,8 +17,6 @@ from zoneinfo import ZoneInfo
 import uvloop
 from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.exceptions import RequestValidationError
-from fhir.resources.capabilitystatement import CapabilityStatement
-from fhir.resources.operationoutcome import OperationOutcome
 from pydantic.error_wrappers import display_errors
 
 from .exceptions import FHIRException
@@ -38,6 +36,7 @@ from .functions import (
 )
 from .interactions import ResourceType, TypeInteraction
 from .providers import FHIRProvider
+from .resources import CapabilityStatement, OperationOutcome
 from .search_parameters import (
     SearchParameters,
     search_parameter_sort_key,

--- a/fhirstarter/functions.py
+++ b/fhirstarter/functions.py
@@ -19,8 +19,6 @@ from inspect import Parameter, signature
 from typing import cast
 
 from fastapi import Body, Form, Path, Query, Request, Response
-from fhir.resources.fhirtypes import Id
-from fhir.resources.resource import Resource
 
 from .exceptions import FHIRBadRequestError
 from .interactions import (
@@ -32,6 +30,7 @@ from .interactions import (
     TypeInteraction,
     UpdateInteractionHandler,
 )
+from .resources import Id, Resource
 from .search_parameters import (
     search_parameter_sort_key,
     supported_search_parameters,

--- a/fhirstarter/interactions.py
+++ b/fhirstarter/interactions.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass
 from typing import Any, Generic, Literal, Protocol, TypeVar
 
 from fastapi import Request, Response
-from fhir.resources.bundle import Bundle
-from fhir.resources.fhirtypes import Id
-from fhir.resources.resource import Resource
+
+from .resources import Bundle, Id, Resource
 
 ResourceType = TypeVar("ResourceType", bound=Resource)
 

--- a/fhirstarter/providers.py
+++ b/fhirstarter/providers.py
@@ -4,7 +4,6 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Protocol, TypeVar
 
 from fastapi import params
-from fhir.resources.resource import Resource
 
 from .interactions import (
     CreateInteraction,
@@ -19,6 +18,7 @@ from .interactions import (
     UpdateInteraction,
     UpdateInteractionHandler,
 )
+from .resources import Resource
 
 C = TypeVar("C", bound=Callable[..., Any])
 

--- a/fhirstarter/resources.py
+++ b/fhirstarter/resources.py
@@ -1,0 +1,44 @@
+"""
+Resources module that finesses imports of resources used by the framework so that they can be
+referenced by the same names across the framework regardless of the FHIR version being used.
+
+The finesse required here is due to what is supported and not supported by various versions of the
+fhir.resources package. Versions including and after 7.0.0 no longer support the R4 sequence, but do
+support the STU3, R4B, and R5 sequences. Version 6.5.0 supports the R4 sequence.
+
+Due to this, the allowed versions of the fhir.resources package will be restricted based on the FHIR
+sequence being used.
+"""
+
+import os
+
+FHIR_SEQUENCE = os.getenv("FHIR_SEQUENCE", "R5")
+
+if FHIR_SEQUENCE == "R4":
+    from fhir.resources.bundle import Bundle
+    from fhir.resources.capabilitystatement import CapabilityStatement
+    from fhir.resources.fhirtypes import Id
+    from fhir.resources.operationoutcome import OperationOutcome
+    from fhir.resources.resource import Resource
+else:
+    match FHIR_SEQUENCE:
+        case "STU3":
+            from fhir.resources.STU3.bundle import Bundle
+            from fhir.resources.STU3.capabilitystatement import CapabilityStatement
+            from fhir.resources.STU3.fhirtypes import Id
+            from fhir.resources.STU3.operationoutcome import OperationOutcome
+            from fhir.resources.STU3.resource import Resource
+        case "R4B":
+            from fhir.resources.R4B.bundle import Bundle
+            from fhir.resources.R4B.capabilitystatement import CapabilityStatement
+            from fhir.resources.R4B.fhirtypes import Id
+            from fhir.resources.R4B.operationoutcome import OperationOutcome
+            from fhir.resources.R4B.resource import Resource
+        case "R5":
+            from fhir.resources.bundle import Bundle
+            from fhir.resources.capabilitystatement import CapabilityStatement
+            from fhir.resources.fhirtypes import Id
+            from fhir.resources.operationoutcome import OperationOutcome
+            from fhir.resources.resource import Resource
+
+__all__ = ["Bundle", "CapabilityStatement", "Id", "OperationOutcome", "Resource"]

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -7,13 +7,11 @@ from typing import Any, ClassVar, Literal
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
-from fhir.resources.bundle import Bundle
-from fhir.resources.operationoutcome import OperationOutcome
-from fhir.resources.resource import Resource
 
 from . import status
 from .fhir_specification.utils import is_resource_type
 from .interactions import ResourceType, SearchTypeInteraction, TypeInteraction
+from .resources import Bundle, OperationOutcome, Resource
 
 
 @dataclass

--- a/poetry.lock
+++ b/poetry.lock
@@ -255,23 +255,23 @@ test = ["anyio[trio] (>=3.2.1,<4.0.0)", "black (==23.1.0)", "coverage[toml] (>=6
 
 [[package]]
 name = "fhir-resources"
-version = "6.4.0"
+version = "7.0.2"
 description = "FHIR Resources as Model Class"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "fhir.resources-6.4.0-py2.py3-none-any.whl", hash = "sha256:226ff1939078efea79a0abec0cc26aa6e3b8bf6e943e4d55a66dd7713f6988bd"},
-    {file = "fhir.resources-6.4.0.tar.gz", hash = "sha256:8f380f108b6cfc8b445138d775b302a09b365a8d2dce60beacfebe11db1d70af"},
+    {file = "fhir.resources-7.0.2-py2.py3-none-any.whl", hash = "sha256:ba16b3348821614650dd2e7f04db170210ce4406f65a5cc873beb10317d595ff"},
+    {file = "fhir.resources-7.0.2.tar.gz", hash = "sha256:1e6392f7bc3b143463b07ada87a3b6a92dd8fe97947670423317fea69226f6de"},
 ]
 
 [package.dependencies]
-pydantic = {version = ">=1.7.2", extras = ["email"]}
+pydantic = {version = ">=1.7.2,<2.0.0", extras = ["email"]}
 
 [package.extras]
 all = ["PyYAML (>=5.4.1)", "lxml", "orjson (>=3.4.3)"]
-dev = ["Jinja2 (==2.11.1)", "MarkupSafe (==1.1.1)", "black", "certifi", "colorlog (==2.10.0)", "coverage", "fhirspec", "flake8 (==3.8.3)", "flake8-bugbear (==20.1.4)", "flake8-isort (==3.0.0)", "isort (==4.3.21)", "mypy (==0.812)", "pytest (>5.4.0)", "pytest-cov (>=2.10.0)", "requests (==2.23.0)", "zest-releaser[recommended]"]
+dev = ["Jinja2 (==2.11.1)", "MarkupSafe (==1.1.1)", "black", "certifi", "colorlog (==2.10.0)", "coverage", "fhirspec", "flake8 (==5.0.4)", "flake8-bugbear (==20.1.4)", "flake8-isort (==4.2.0)", "isort (==4.3.21)", "mypy (==0.812)", "pytest (>5.4.0)", "pytest-cov (>=2.10.0)", "requests (==2.23.0)", "setuptools (==65.6.3)", "zest-releaser[recommended]"]
 orjson = ["orjson (>=3.4.3)"]
-test = ["PyYAML (>=5.4.1)", "black", "coverage", "flake8 (==3.8.3)", "flake8-bugbear (==20.1.4)", "flake8-isort (==3.0.0)", "isort (==4.3.21)", "lxml", "mypy (==0.812)", "orjson (>=3.4.3)", "pytest (>5.4.0)", "pytest-cov (>=2.10.0)", "pytest-runner", "requests (==2.23.0)"]
+test = ["PyYAML (>=5.4.1)", "black", "coverage", "flake8 (==5.0.4)", "flake8-bugbear (==20.1.4)", "flake8-isort (==4.2.0)", "isort (==4.3.21)", "lxml", "mypy (==0.812)", "orjson (>=3.4.3)", "pytest (>5.4.0)", "pytest-cov (>=2.10.0)", "pytest-runner", "requests (==2.23.0)", "setuptools (==65.6.3)"]
 xml = ["lxml"]
 yaml = ["PyYAML (>=5.4.1)"]
 
@@ -1083,4 +1083,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "46457a92fd6bb337b1214cf243089d69850194521d0f14d0c9c739997da107c4"
+content-hash = "d5833e1750311b5213ed030195bc15806f50f60e26bcaedda9578601e138fe8c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1083,4 +1083,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d5833e1750311b5213ed030195bc15806f50f60e26bcaedda9578601e138fe8c"
+content-hash = "0109e2ddbb14db1f25f96fa6577e832951398dcc8aa01eeb6127919e09ee891f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.94.1"
-"fhir.resources" = ">=6.5.0"
+"fhir.resources" = ">=6.4.0"
 lxml = "^4.9.2"
 python-multipart = "^0.0.6"
 uvloop = "^0.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.94.1"
-"fhir.resources" = "~6.4.0"
+"fhir.resources" = ">=6.5.0"
 lxml = "^4.9.2"
 python-multipart = "^0.0.6"
 uvloop = "^0.17.0"


### PR DESCRIPTION
* Added an environment variable for users to specify which FHIR version the server uses
* Added controls around which version of `fhir.resources` package can be installed based on the FHIR version
* Created a resources module to normalized how FHIR resources are imported