### PR TITLE
Minor test refactoring, and a parameter rename, and more flexibility loading config file

### DIFF
--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -93,7 +93,7 @@ class FHIRStarter(FastAPI):
 
         if config_file_name:
             logging.warning(
-                "The config_file_name argument to FHIRStarter.__init__ has been deprecated and will be removed in a future release."
+                "The config_file_name parameter to FHIRStarter.__init__ has been deprecated and will be removed in a future release."
             )
             if not config_file:
                 config_file = config_file_name

--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -93,7 +93,8 @@ class FHIRStarter(FastAPI):
 
         if config_file_name:
             logging.warning(
-                "The config_file_name parameter to FHIRStarter.__init__ has been deprecated and will be removed in a future release."
+                "The config_file_name parameter to FHIRStarter.__init__ has been deprecated and "
+                "will be removed in a future release."
             )
             if not config_file:
                 config_file = config_file_name

--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -100,10 +100,10 @@ class FHIRStarter(FastAPI):
                 config_file = config_file_name
 
         if config_file:
-            if isinstance(config_file, IOBase):
-                config_file.seek(0)
+            try:
+                cast(IOBase, config_file).seek(0)
                 config = tomllib.load(config_file)
-            else:
+            except AttributeError:
                 with open(config_file, "rb") as file_:
                     config = tomllib.load(file_)
 

--- a/fhirstarter/scripts/example.py
+++ b/fhirstarter/scripts/example.py
@@ -22,7 +22,7 @@ from fhirstarter.exceptions import FHIRResourceNotFoundError
 # Create the app with the provided config file
 app = FHIRStarter(
     title="FHIRStarter Example Implementation",
-    config_file_name=Path(__file__).parent / "config.toml",
+    config_file=Path(__file__).parent / "config.toml",
 )
 
 # Create a "database"

--- a/fhirstarter/tests/config.py
+++ b/fhirstarter/tests/config.py
@@ -126,29 +126,37 @@ include-in-capability-statement = true
     return TestClient(app)
 
 
-def create_test_client(
-    interactions: tuple[str, ...], async_endpoints: bool
-) -> TestClient:
-    """Given a list of interactions and an async flag, create an app and return a test client."""
+def create_test_client_async(interactions: tuple[str, ...]) -> TestClient:
+    """Given a list of interactions, create an app with async handlers and return a test client."""
     provider = FHIRProvider()
 
     for interaction in interactions:
-        match interaction, async_endpoints:
-            case "create", True:
+        match interaction:
+            case "create":
                 provider.create(Patient)(patient_create_async)
-            case "create", False:
-                provider.create(Patient)(patient_create)
-            case "read", True:
+            case "read":
                 provider.read(Patient)(patient_read_async)
-            case "read", False:
-                provider.read(Patient)(patient_read)
-            case "search-type", True:
+            case "search-type":
                 provider.search_type(Patient)(patient_search_type_async)
-            case "search-type", False:
-                provider.search_type(Patient)(patient_search_type)
-            case "update", True:
+            case "update":
                 provider.update(Patient)(patient_update_async)
-            case "update", False:
+
+    return app(provider)
+
+
+def create_test_client(interactions: tuple[str, ...]) -> TestClient:
+    """Given a list of interactions, create an app and return a test client."""
+    provider = FHIRProvider()
+
+    for interaction in interactions:
+        match interaction:
+            case "create":
+                provider.create(Patient)(patient_create)
+            case "read":
+                provider.read(Patient)(patient_read)
+            case "search-type":
+                provider.search_type(Patient)(patient_search_type)
+            case "update":
                 provider.update(Patient)(patient_update)
 
     return app(provider)

--- a/fhirstarter/tests/config.py
+++ b/fhirstarter/tests/config.py
@@ -117,7 +117,7 @@ include-in-capability-statement = true
     with NamedTemporaryFile("w") as config_file:
         config_file.write(config_file_contents)
         config_file.seek(0)
-        app = FHIRStarter(config_file_name=config_file.name)
+        app = FHIRStarter(config_file=config_file.name)
 
     app.add_providers(provider)
 

--- a/fhirstarter/tests/conftest.py
+++ b/fhirstarter/tests/conftest.py
@@ -1,38 +1,44 @@
 """FHIRStarter test fixtures"""
 
+from collections.abc import Callable
+
 import pytest
 from _pytest.fixtures import FixtureRequest
 
 from ..testclient import TestClient
-from .config import create_test_client
+from .config import create_test_client, create_test_client_async
 
 
-@pytest.fixture(scope="session", params=[True, False], ids=["async", "nonasync"])
-def async_endpoints(request: FixtureRequest) -> bool:
+@pytest.fixture(
+    scope="session",
+    params=[create_test_client_async, create_test_client],
+    ids=["async", "nonasync"],
+)
+def create_test_client_func(request: FixtureRequest) -> bool:
     """Parametrized fixture to ensure that all tests are tested in both async and nonasync modes."""
     return request.param
 
 
 @pytest.fixture
-def client(request: FixtureRequest, async_endpoints: bool) -> TestClient:
+def client(
+    request: FixtureRequest,
+    create_test_client_func: Callable[[tuple[str, ...]], TestClient],
+) -> TestClient:
     """Return a test client with specified interactions enabled."""
-    return create_test_client(
-        interactions=request.param, async_endpoints=async_endpoints
-    )
+    return create_test_client_func(request.param)
 
 
 @pytest.fixture
-def client_all(async_endpoints: bool) -> TestClient:
+def client_all(
+    create_test_client_func: Callable[[tuple[str, ...]], TestClient]
+) -> TestClient:
     """Return a test client with all interactions enabled."""
-    return create_test_client(
-        interactions=("create", "read", "search-type", "update"),
-        async_endpoints=async_endpoints,
-    )
+    return create_test_client_func(("create", "read", "search-type", "update"))
 
 
 @pytest.fixture
-def client_create_and_read(async_endpoints: bool) -> TestClient:
+def client_create_and_read(
+    create_test_client_func: Callable[[tuple[str, ...]], TestClient]
+) -> TestClient:
     """Return a test client with the create and read interactions enabled."""
-    return create_test_client(
-        interactions=("create", "read"), async_endpoints=async_endpoints
-    )
+    return create_test_client_func(("create", "read"))

--- a/fhirstarter/tests/test_interactions.py
+++ b/fhirstarter/tests/test_interactions.py
@@ -14,13 +14,7 @@ from ..providers import FHIRProvider
 from ..resources import Bundle
 from ..testclient import TestClient
 from ..utils import make_operation_outcome
-from .config import (
-    DATABASE,
-    app,
-    create_test_client,
-    patient_create,
-    patient_create_async,
-)
+from .config import DATABASE, app, patient_create, patient_create_async
 from .resources import HumanName, Patient
 from .utils import (
     assert_expected_response,
@@ -32,12 +26,11 @@ from .utils import (
 
 
 @pytest.fixture(scope="module")
-def client(async_endpoints: bool) -> TestClient:
+def client(
+    create_test_client_func: Callable[[tuple[str, ...]], TestClient]
+) -> TestClient:
     """Return a module-scoped test client with all interactions enabled."""
-    return create_test_client(
-        interactions=("create", "read", "search-type", "update"),
-        async_endpoints=async_endpoints,
-    )
+    return create_test_client_func(("create", "read", "search-type", "update"))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* Refactored the test fixture that ensures that tests run in both async and sync modes so that it uses functions as parameters instead of booleans
* Split the function that creates a test application and client into two functions, one for async and one for non-async
* Added some flexibility in how the config file is loaded; now can accept an open file or a filename
* Renamed config file parameter and deprecated old name