### PR TITLE
Enhance parse_fhir_operation helper function to recognize FHIR operations

### DIFF
--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ..utils import InteractionInfo, parse_fhir_request
+from ..utils import ParsedRequest, parse_fhir_request
 from .utils import generate_fhir_resource_id, make_request
 
 
@@ -19,175 +19,239 @@ from .utils import generate_fhir_resource_id, make_request
                 "capabilitites",
                 "GET",
                 "/metadata",
-                InteractionInfo(  # type: ignore[call-arg]
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
                     resource_type=None,
-                    interaction_type="capabilities",
                     resource_id=None,
+                    interaction_type="capabilities",
                 ),
             ),
             (
                 "read",
                 "GET",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type="Patient", interaction_type="read", resource_id=id_
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    interaction_type="read",
                 ),
             ),
             (
                 "read unrecognized resource type",
                 "GET",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "update",
                 "PUT",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type="Patient", interaction_type="update", resource_id=id_
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    interaction_type="update",
                 ),
             ),
             (
                 "update unrecognized resource type",
                 "PUT",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "patch",
                 "PATCH",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type="Patient", interaction_type="patch", resource_id=id_
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    interaction_type="patch",
                 ),
             ),
             (
                 "patch unrecognized resource type",
                 "PATCH",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "delete",
                 "DELETE",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type="Patient", interaction_type="delete", resource_id=id_
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    interaction_type="delete",
                 ),
             ),
             (
                 "delete unrecognized resource type",
                 "DELETE",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "create",
                 "POST",
                 "/Patient",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type="Patient", interaction_type="create", resource_id=None
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
+                    resource_type="Patient",
+                    resource_id=None,
+                    interaction_type="create",
                 ),
             ),
             (
                 "create unrecognized resource type",
                 "POST",
                 "/FakeResource",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "search-type",
                 "GET",
                 "/Patient",
-                InteractionInfo(  # type: ignore[call-arg]
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
                     resource_type="Patient",
-                    interaction_type="search-type",
                     resource_id=None,
+                    interaction_type="search-type",
                 ),
             ),
             (
                 "search-type post",
                 "POST",
                 "/Patient/_search",
-                InteractionInfo(  # type: ignore[call-arg]
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="interaction",
                     resource_type="Patient",
-                    interaction_type="search-type",
                     resource_id=None,
+                    interaction_type="search-type",
                 ),
             ),
             (
                 "search unrecognized resource type",
                 "GET",
                 f"/FakeResource",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "search POST unrecognized resource type",
                 "POST",
                 "/FakeResource/_search",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
+                ParsedRequest(),
+            ),
+            (
+                "operation GET",
+                "GET",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    operation_name="export",
                 ),
+            ),
+            (
+                "operation POST",
+                "POST",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type="Patient",
+                    resource_id=id_,
+                    operation_name="export",
+                ),
+            ),
+            (
+                "operation-type GET",
+                "GET",
+                f"/Patient/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type="Patient",
+                    resource_id=None,
+                    operation_name="export",
+                ),
+            ),
+            (
+                "operation-type POST",
+                "POST",
+                f"/Patient/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type="Patient",
+                    resource_id=None,
+                    operation_name="export",
+                ),
+            ),
+            (
+                "operation-system GET",
+                "GET",
+                f"/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type=None,
+                    resource_id=None,
+                    operation_name="export",
+                ),
+            ),
+            (
+                "operation-system POST",
+                "POST",
+                f"/$export",
+                ParsedRequest(  # type: ignore[call-arg]
+                    request_type="operation",
+                    resource_type=None,
+                    resource_id=None,
+                    operation_name="export",
+                ),
+            ),
+            (
+                "operation PUT (invalid request)",
+                "PUT",
+                f"/Patient/{(id_ := generate_fhir_resource_id())}/$export",
+                ParsedRequest(),
             ),
             (
                 "unrecognized GET path",
                 "GET",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "unrecognized PUT path",
                 "PUT",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "unrecognized POST path",
                 "POST",
                 "/FakeResource/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "unrecognized PATCH path",
                 "PATCH",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "unrecognized DELETE path",
                 "DELETE",
                 f"/FakeResource/{(id_ := generate_fhir_resource_id())}/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
             (
                 "unsupported HTTP method",
                 "HEAD",
                 f"/Patient/{(id_ := generate_fhir_resource_id())}/extra",
-                InteractionInfo(  # type: ignore[call-arg]
-                    resource_type=None, interaction_type=None, resource_id=None
-                ),
+                ParsedRequest(),
             ),
         ]
     ),
@@ -198,7 +262,7 @@ def test_parse_fhir_request(
     mount_path: str,
     request_method: str,
     path: str,
-    expected_result: InteractionInfo,
+    expected_result: ParsedRequest,
 ) -> None:
     assert (
         parse_fhir_request(make_request(request_method, f"{mount_path}{path}"))

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -1,7 +1,7 @@
 """Miscellaneous utility functions."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Dict, Literal, Union
+from typing import Any, Callable, ClassVar, Dict, Literal, Sequence, Union
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
@@ -29,107 +29,127 @@ class ParsedRequest:
 def parse_fhir_request(request: Request) -> ParsedRequest:
     """
     Parse a FHIR request into its component parts, and determine an interaction type or operation
-    name.
+    name. Return a ParsedRequest object with the information.
+
+    If this function isn't able to identify the request as a FHIR request, then an empty
+    ParsedRequest object will be returned.
 
     Note: This function is currently oriented around specific use cases for this framework.
     Specifically, it will correctly categorize read, update, patch, create, search-type, and
     capabilities interactions, and will identify operations. Further enhancement is needed to
     support more use cases.
     """
-    # If this function isn't able to identify the request as a FHIR request, then this empty
-    # ParsedRequest object will be returned
-    no_info = ParsedRequest()
-
     split_path = request.url.path.split("/")
     if not split_path:
-        return no_info
+        return ParsedRequest()
 
-    path_parts_count = len(split_path)
+    if split_path[-1].startswith("$"):
+        return _parse_fhir_operation_request(request, split_path)
+    else:
+        return _parse_fhir_interaction_request(request, split_path)
+
+
+def _parse_fhir_operation_request(
+    request: Request, split_path: Sequence[str]
+) -> ParsedRequest:
+    """Parse a potential FHIR operation request."""
+    # The request may be a FHIR operation -- make sure the method is either a GET or POST
+    if request.method not in ("GET", "POST"):
+        return ParsedRequest()
 
     resource_type = None
     resource_id = None
-    interaction_type = None
-    operation_name = None
 
-    if split_path[-1].startswith("$"):
-        # The request may be a FHIR operation -- make sure the method is either a GET or POST
-        if request.method not in ("GET", "POST"):
-            return no_info
+    # Determine the operation name
+    operation_name = split_path[-1]
+    if operation_name and operation_name[0] == "$":
+        operation_name = operation_name[1:]
 
-        request_type = "operation"
-        operation_name = split_path[-1]
-        if operation_name and operation_name[0] == "$":
-            operation_name = operation_name[1:]
-
-        # If neither of these conditions are met, then it's an operation on the base URL
-        if path_parts_count >= 3 and is_resource_type(split_path[-3]):
-            # Instance operation
-            resource_type = split_path[-3]
-            resource_id = split_path[-2]
-        elif path_parts_count >= 2 and is_resource_type(split_path[-2]):
-            # Type operation
-            resource_type = split_path[-2]
-    else:
-        # The request may be a FHIR interaction -- determine what it is based on the request method
-        # and the URL format
-        request_type = "interaction"
-
-        if request.method == "GET":
-            if split_path[-1] == "metadata":
-                interaction_type = "capabilities"
-            elif is_resource_type(split_path[-1]):
-                resource_type = split_path[-1]
-                interaction_type = "search-type"
-            elif path_parts_count >= 3:
-                resource_type = split_path[-2]
-                resource_id = split_path[-1]
-                interaction_type = "read"
-            else:
-                return no_info
-        elif request.method == "POST":
-            if is_resource_type(split_path[-1]):
-                resource_type = split_path[-1]
-                interaction_type = "create"
-            elif split_path[-1] == "_search":
-                resource_type = split_path[-2]
-                interaction_type = "search-type"
-            else:
-                return no_info
-        elif request.method == "PUT":
-            if path_parts_count >= 3:
-                resource_type = split_path[-2]
-                resource_id = split_path[-1]
-                interaction_type = "update"
-            else:
-                return no_info
-        elif request.method == "PATCH":
-            if path_parts_count >= 3:
-                resource_type = split_path[-2]
-                resource_id = split_path[-1]
-                interaction_type = "patch"
-            else:
-                return no_info
-        elif request.method == "DELETE":
-            if path_parts_count >= 3:
-                resource_type = split_path[-2]
-                resource_id = split_path[-1]
-                interaction_type = "delete"
-            else:
-                return no_info
-        else:
-            return no_info
-
-        # If the resource type found is not an actual resource type, then it's not a FHIR
-        # interaction
-        if resource_type and not is_resource_type(resource_type):
-            return no_info
+    # If neither of these conditions are met, then it's an operation on the base URL
+    path_parts_count = len(split_path)
+    if path_parts_count >= 3 and is_resource_type(split_path[-3]):
+        # Instance operation -- get the resource type and path
+        resource_type = split_path[-3]
+        resource_id = split_path[-2]
+    elif path_parts_count >= 2 and is_resource_type(split_path[-2]):
+        # Type operation -- get the resource type
+        resource_type = split_path[-2]
 
     return ParsedRequest(  # type: ignore[call-arg]
-        request_type=request_type,
+        request_type="operation",
+        resource_type=resource_type,
+        resource_id=resource_id,
+        operation_name=operation_name,
+    )
+
+
+def _parse_fhir_interaction_request(
+    request: Request, split_path: Sequence[str]
+) -> ParsedRequest:
+    """Parse a potential FHIR interaction request."""
+    # The request may be a FHIR interaction -- determine what it is based on the request method
+    # and the URL format
+    resource_type = None
+    resource_id = None
+    interaction_type: Union[str, None]
+
+    path_parts_count = len(split_path)
+
+    if request.method == "GET":
+        if split_path[-1] == "metadata":
+            interaction_type = "capabilities"
+        elif is_resource_type(split_path[-1]):
+            resource_type = split_path[-1]
+            interaction_type = "search-type"
+        elif path_parts_count >= 3:
+            resource_type = split_path[-2]
+            resource_id = split_path[-1]
+            interaction_type = "read"
+        else:
+            return ParsedRequest()
+    elif request.method == "POST":
+        if is_resource_type(split_path[-1]):
+            resource_type = split_path[-1]
+            interaction_type = "create"
+        elif split_path[-1] == "_search":
+            resource_type = split_path[-2]
+            interaction_type = "search-type"
+        else:
+            return ParsedRequest()
+    elif request.method == "PUT":
+        if path_parts_count >= 3:
+            resource_type = split_path[-2]
+            resource_id = split_path[-1]
+            interaction_type = "update"
+        else:
+            return ParsedRequest()
+    elif request.method == "PATCH":
+        if path_parts_count >= 3:
+            resource_type = split_path[-2]
+            resource_id = split_path[-1]
+            interaction_type = "patch"
+        else:
+            return ParsedRequest()
+    elif request.method == "DELETE":
+        if path_parts_count >= 3:
+            resource_type = split_path[-2]
+            resource_id = split_path[-1]
+            interaction_type = "delete"
+        else:
+            return ParsedRequest()
+    else:
+        return ParsedRequest()
+
+    # If the resource type found is not an actual resource type, then it's not a FHIR
+    # interaction
+    if resource_type and not is_resource_type(resource_type):
+        return ParsedRequest()
+
+    return ParsedRequest(  # type: ignore[call-arg]
+        request_type="interaction",
         resource_type=resource_type,
         resource_id=resource_id,
         interaction_type=interaction_type,
-        operation_name=operation_name,
     )
 
 
@@ -289,7 +309,8 @@ def read_route_args(interaction: TypeInteraction[ResourceType]) -> Dict[str, Any
             _not_found,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|instance|read|get|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|instance|read|get|{resource_type_str}|"
+        f"{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -317,7 +338,8 @@ def update_route_args(interaction: TypeInteraction[ResourceType]) -> Dict[str, A
             _unprocessable_entity,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|instance|update|put|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|instance|update|put|{resource_type_str}|"
+        f"{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -346,7 +368,8 @@ def patch_route_args(interaction: TypeInteraction[ResourceType]) -> Dict[str, An
             _unprocessable_entity,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|instance|patch|patch|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|instance|patch|patch|{resource_type_str}|"
+        f"{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -371,7 +394,8 @@ def delete_route_args(interaction: TypeInteraction[ResourceType]) -> Dict[str, A
             _forbidden,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|instance|delete|delete|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|instance|delete|delete|{resource_type_str}|"
+        f"{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -398,7 +422,8 @@ def create_route_args(interaction: TypeInteraction[ResourceType]) -> Dict[str, A
             _unprocessable_entity,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|type|create|post|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|type|create|post|{resource_type_str}|"
+        f"{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -426,7 +451,9 @@ def search_type_route_args(
             _forbidden,
             _internal_server_error,
         ),
-        "operation_id": f"fhirstarter|type|search-type|{'post' if post else 'get'}|{resource_type_str}|{interaction.resource_type.__module__}|{interaction.resource_type.__name__}",
+        "operation_id": f"fhirstarter|type|search-type|{'post' if post else 'get'}|"
+        f"{resource_type_str}|{interaction.resource_type.__module__}|"
+        f"{interaction.resource_type.__name__}",
         "response_model_exclude_none": True,
         **interaction.route_options,
     }
@@ -545,6 +572,7 @@ def _internal_server_error(_: TypeInteraction[ResourceType]) -> _Responses:
     return {
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
             "model": OperationOutcome,
-            "description": f"The server has encountered a situation it does not know how to handle.",
+            "description": f"The server has encountered a situation it does not know how to "
+            "handle.",
         }
     }

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -36,6 +36,8 @@ def parse_fhir_request(request: Request) -> ParsedRequest:
     capabilities interactions, and will identify operations. Further enhancement is needed to
     support more use cases.
     """
+    # If this function isn't able to identify the request as a FHIR request, then this empty
+    # ParsedRequest object will be returned
     no_info = ParsedRequest()
 
     split_path = request.url.path.split("/")

--- a/poetry.lock
+++ b/poetry.lock
@@ -471,7 +471,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 files = [
     {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
-    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
 ]
 
 [[package]]
@@ -870,7 +869,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -878,16 +876,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -904,7 +894,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -912,7 +901,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fhirstarter"
-version = "2.2.2"
+version = "2.3.0"
 description = "An ASGI FHIR API framework built on top of FastAPI and FHIR Resources"
 authors = ["Christopher Sande <christopher.sande@canvasmedical.com>"]
 maintainers = ["Canvas Medical Engineering <engineering@canvasmedical.com>"]


### PR DESCRIPTION
FHIRStarter doesn't support operations yet, but for APIs that support them through FastAPI, it is useful to be able to parse and identify them.

This PR enhances the `parse_fhir_request` helper function so that it can recognize operations.