### PR TITLE
feat: Add support for Python 3.14+ and FastAPI 0.128+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fhirstarter"
-version = "3.0.0"
+version = "3.0.0+sehat.1"
 description = "An ASGI FHIR API framework built on top of FastAPI and FHIR Resources"
 authors = ["Christopher Sande <christopher.sande@canvasmedical.com>"]
 maintainers = ["Canvas Medical Engineering <engineering@canvasmedical.com>"]
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
@@ -36,15 +37,15 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8.0,<3.14.0"
+python = ">=3.8.0,<3.16.0"
 asyncache = "^0.3.1"
 cachetools = "^5.5.1"
 eval-type-backport = "^0.2.2"
-fastapi = ">=0.103.1,<0.117.0"
+fastapi = ">=0.103.1,<0.130.0"
 "fhir.resources" = {version = ">=8.0.0,<9.0.0", extras = ["xml"]}
 httpx = ">=0.24.1,<0.29.0"
 orjson = "^3.10.3"
-python-multipart = ">=0.0.6,<0.0.21"
+python-multipart = ">=0.0.6,<0.1.0"
 tomli = { version = ">=2.0.1,<3.0.0", markers = "python_version < '3.11'" }
 tzdata = { version = ">=2023.3,<2026.0", markers = "platform_system == 'Windows'" }
 


### PR DESCRIPTION
- Expand Python support from <3.14.0 to <3.16.0
- Expand FastAPI support from <0.117.0 to <0.130.0
- Expand python-multipart support from <0.0.21 to <0.1.0
- Add Python 3.14 classifier
- Version bump to 3.0.0+sehat.1 to indicate fork

This allows usage with modern Python 3.14 and latest FastAPI 0.128 while maintaining backward compatibility with earlier versions.