### PR TITLE
Bump version to 4.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fhirstarter"
-version = "4.0.0"
+version = "4.1.0"
 description = "An ASGI FHIR API framework built on top of FastAPI and FHIR Resources"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ xml = [
 
 [[package]]
 name = "fhirstarter"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncache" },


### PR DESCRIPTION
## Summary
- Bump project version from 4.0.0 to 4.1.0 in `pyproject.toml`
- Refresh `uv.lock` to reflect the new version

## Test plan
- [ ] CI passes (lint + tests across the Python × FHIR sequence matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)