### PR TITLE
Fix from_ field type annotation in JSONPatchOperation

### DIFF
--- a/fhirstarter/json_patch.py
+++ b/fhirstarter/json_patch.py
@@ -14,7 +14,7 @@ class JSONPatchOperation(BaseModel):
     """
 
     op: Literal["add", "remove", "replace", "move", "copy", "test"]
-    from_: str = Field(default=None, alias="from")
+    from_: str | None = Field(default=None, alias="from")
     path: str
     value: Any | None
 


### PR DESCRIPTION
## Summary
- `JSONPatchOperation.from_` was annotated as `str` but defaults to `None` and is validated as optional (only required for `move`/`copy` ops via `_check_optional_field`).
- Newer `ty` versions correctly flag this as `invalid-assignment`, which surfaces as a Lint workflow failure on PR #373 (renovate lock-file maintenance) and any PR that bumps `ty`.
- Fix: annotate as `str | None` to match actual semantics. No behavior change.

## Test plan
- [x] `uv run ty check` passes
- [x] `prek run --all-files` passes
- [x] Patch interaction tests pass (`pytest -k patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)