### PR TITLE
Strip empty arrays and objects from JSON responses

### DIFF
--- a/fhirstarter/tests/test_utils.py
+++ b/fhirstarter/tests/test_utils.py
@@ -1,8 +1,17 @@
 """Test FHIR utils"""
 
+from typing import Any
+
+import orjson
 import pytest
 
-from ..utils import ParsedRequest, parse_fhir_request
+from ..utils import (
+    ParsedRequest,
+    format_response,
+    parse_fhir_request,
+    prune_empty_elements,
+)
+from .resources import Patient
 from .utils import generate_fhir_resource_id, make_request
 
 
@@ -268,3 +277,115 @@ def test_parse_fhir_request(
         parse_fhir_request(make_request(request_method, f"{mount_path}{path}"))
         == expected_result
     )
+
+
+# A deeply nested (four-plus levels) structure that exercises the recursive pruner:
+# empty containers are buried several levels down, empties-of-empties collapse upward,
+# and real data plus falsy scalars survive at every level.
+_DEEP_INPUT = {
+    "resourceType": "Bundle",
+    "total": 0,  # falsy scalar — kept
+    "entry": [  # level 1
+        {
+            "resource": {  # level 2
+                "resourceType": "Patient",
+                "active": False,  # falsy scalar — kept
+                "photo": [{}, {}],  # collapses entirely -> removed
+                "contact": [  # level 3
+                    {  # level 4
+                        "name": {"family": "Doe", "given": []},  # given [] pruned
+                        "telecom": [{}],  # [{}] -> [] -> removed
+                        "relationship": [],  # pruned
+                    },
+                    {"telecom": [{"system": ""}]},  # "" kept -> item survives
+                ],
+                # A whole branch of nothing: coding [] -> language {} -> item {} ->
+                # communication [] -> removed entirely.
+                "communication": [{"language": {"coding": []}}],
+            }
+        },
+        # note[0].extension [] -> note[0] {} -> note [] -> removed
+        {"resource": {"resourceType": "Observation", "note": [{"extension": []}]}},
+    ],
+}
+
+_DEEP_EXPECTED = {
+    "resourceType": "Bundle",
+    "total": 0,
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "active": False,
+                "contact": [
+                    {"name": {"family": "Doe"}},
+                    {"telecom": [{"system": ""}]},
+                ],
+            }
+        },
+        {"resource": {"resourceType": "Observation"}},
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    argnames="value,expected",
+    argvalues=[
+        pytest.param(
+            {"resourceType": "Patient", "communication": []},
+            {"resourceType": "Patient"},
+            id="empty list removed",
+        ),
+        pytest.param(
+            {"resourceType": "Patient", "text": {}},
+            {"resourceType": "Patient"},
+            id="empty dict removed",
+        ),
+        pytest.param(
+            {"total": 0, "active": False, "note": ""},
+            {"total": 0, "active": False, "note": ""},
+            id="falsy scalars preserved",
+        ),
+        pytest.param(
+            {"name": [{"given": [], "family": "Doe"}], "x": [{}]},
+            {"name": [{"family": "Doe"}]},
+            id="empties-of-empties collapse",
+        ),
+        pytest.param(
+            [{}, {"a": 1}],
+            [{"a": 1}],
+            id="empty list items pruned",
+        ),
+        pytest.param(
+            {
+                "resourceType": "Patient",
+                "name": [{"family": "Baggins", "given": ["Bilbo"]}],
+            },
+            {
+                "resourceType": "Patient",
+                "name": [{"family": "Baggins", "given": ["Bilbo"]}],
+            },
+            id="non-empty untouched",
+        ),
+        pytest.param(_DEEP_INPUT, _DEEP_EXPECTED, id="deeply nested hierarchical"),
+    ],
+)
+def testprune_empty_elements(value: Any, expected: Any) -> None:
+    assert prune_empty_elements(value) == expected
+
+
+def test_format_response_prunes_empty_elements() -> None:
+    """
+    format_response must strip empty containers that Pydantic v2's model_dump leaves in,
+    so the JSON body conforms to FHIR (empty arrays/objects must be omitted).
+
+    This is the real chokepoint every JSON response flows through. Before the pruner was
+    added, model_dump() emitted "communication": [] and it was serialized as-is.
+    """
+    patient = Patient(**{"name": [{"family": "Baggins"}], "communication": []})
+
+    response = format_response(patient, status_code=200)
+    body = orjson.loads(response.body)
+
+    assert "communication" not in body
+    assert body == {"resourceType": "Patient", "name": [{"family": "Baggins"}]}

--- a/fhirstarter/utils.py
+++ b/fhirstarter/utils.py
@@ -232,6 +232,42 @@ class FormatParameters:
         return None
 
 
+def _is_empty(value: Any) -> bool:
+    """Return whether a value is an empty container that must be omitted from FHIR JSON.
+
+    Only genuinely-empty dicts and lists qualify. Falsy scalars (0, False, "") are valid
+    FHIR values (e.g. Bundle.total == 0) and must be preserved, so a bare falsiness check
+    would be wrong here.
+    """
+    return isinstance(value, (dict, list)) and not value
+
+
+def prune_empty_elements(value: Any) -> Any:
+    """Recursively drop empty objects and arrays from a model_dump() structure.
+
+    FHIR JSON prohibits empty arrays and objects: a repeating element with no entries
+    must be omitted rather than serialized as []. Pydantic v2's model_dump (unlike v1's
+    dict()) preserves these empty containers, so prune them before serialization.
+
+    Pruning is bottom-up so that a container which becomes empty only after its children
+    are pruned is itself removed (e.g. name=[{"given": []}] collapses until the whole
+    `name` key disappears).
+    """
+    if isinstance(value, dict):
+        return {
+            key: cleaned
+            for key, sub in value.items()
+            if not _is_empty(cleaned := prune_empty_elements(sub))
+        }
+    if isinstance(value, list):
+        return [
+            cleaned
+            for item in value
+            if not _is_empty(cleaned := prune_empty_elements(item))
+        ]
+    return value
+
+
 def format_response(
     resource: Resource | None,
     response: Response | None = None,
@@ -259,16 +295,20 @@ def format_response(
         return resource
 
     if format_parameters.format == "application/fhir+json":
+        # Prune empty containers left in by Pydantic v2's model_dump so the JSON body
+        # conforms to FHIR. The XML path below does not have this problem.
+        data = prune_empty_elements(resource.model_dump())
+
         if format_parameters.pretty:
             return Response(
-                content=orjson.dumps(resource.model_dump(), option=orjson.OPT_INDENT_2),
+                content=orjson.dumps(data, option=orjson.OPT_INDENT_2),
                 status_code=status_code or status.HTTP_200_OK,
                 media_type=format_parameters.format,
             )
         else:
             if status_code:
                 return Response(
-                    content=orjson.dumps(resource.model_dump()),
+                    content=orjson.dumps(data),
                     status_code=status_code,
                     media_type=format_parameters.format,
                 )
@@ -278,7 +318,7 @@ def format_response(
                 )
 
                 return Response(
-                    content=orjson.dumps(resource.model_dump()),
+                    content=orjson.dumps(data),
                     media_type=format_parameters.format,
                 )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fhirstarter"
-version = "4.1.0"
+version = "4.1.1"
 description = "An ASGI FHIR API framework built on top of FastAPI and FHIR Resources"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ xml = [
 
 [[package]]
 name = "fhirstarter"
-version = "4.1.0"
+version = "4.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncache" },


### PR DESCRIPTION
## Summary

The upgrade to `fhir.resources` (Pydantic v2) changed model serialization behavior: Pydantic v1's `.dict()`/`.json()` stripped empty containers, but v2's `model_dump()` preserves them. Because `format_response` serializes every JSON response via `model_dump()`, a resource such as:

```json
{"resourceType": "Patient", "communication": []}
```

now emits the empty `communication` array on the wire. FHIR JSON prohibits this — a repeating element with no entries must be [omitted, not serialized as `[]`](https://hl7.org/fhir/R5/json.html). This is a behavioral regression introduced indirectly by a prior `fhir.resources` upgrade, so it is treated as a **bug fix**.

## Changes

- Add a recursive `prune_empty_elements` helper in `utils.py` that removes empty dicts/lists **bottom-up** (so a container that only becomes empty after its children are pruned is itself removed), while **preserving falsy scalars** (`0`, `False`, `""` — e.g. `Bundle.total == 0`).
- Apply it in the JSON branch of `format_response` — the single chokepoint every JSON response (interactions, `OperationOutcome` errors, capability statement, search Bundles) flows through.
- Add unit tests for the pruner, including a deeply-nested (≥4-level) hierarchical case where an all-empty branch collapses entirely, plus an integration test through `format_response`.
- Bump version to `4.1.1`.

## Scope / caveats

- **XML is intentionally not covered.** It is not a first-class feature, and `model_dump_xml` renders an empty list as zero elements anyway, so XML did not exhibit the problem.
- **Empty strings are out of scope and not a regression** — they are rejected at validation time by the FHIR primitive-string regex in both Pydantic v1 and v2, so they never reach serialization.

## Follow-up (deferred, not in this PR)

- Whitespace-only string trimming (`"   "` is accepted by the model) — a separate validation concern.

## Test plan

- `uv run pytest fhirstarter/tests/test_utils.py`
- Full suite across all sequences: `FHIR_SEQUENCE={R5,R4B,STU3} uv run pytest` — all green.
- `prek run --all-files` (ruff + ty) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)