### PR TITLE
Unblock lockfile maintenance

### DIFF
--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -194,7 +194,7 @@ class FHIRStarter(FastAPI):
         for interaction in sorted(
             sorted(
                 provider_interactions,
-                key=lambda i: cast(str, i.resource_type.get_resource_type()),
+                key=lambda i: i.resource_type.get_resource_type(),
             ),
             key=lambda i: _INTERACTION_ORDER[i.label()],
         ):
@@ -376,7 +376,7 @@ class FHIRStarter(FastAPI):
                 resource["searchParam"] = sorted(
                     supported_search_parameters_,
                     key=lambda p: parameter_sort_key(
-                        cast(dict[str, str], p)["name"], search_parameter_metadata
+                        p["name"], search_parameter_metadata
                     ),
                 )
             resources.append(resource)

--- a/fhirstarter/tests/utils.py
+++ b/fhirstarter/tests/utils.py
@@ -54,7 +54,8 @@ def make_request(
     parsed_path = urlparse(path)
 
     path = parsed_path.path
-    query_string = parsed_path.query
+    # The ASGI spec requires a bytestring here; Starlette decodes it directly.
+    query_string = parsed_path.query.encode()
 
     return Request(
         scope={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,16 @@ dev = [
 requires = ["uv_build>=0.5.0,<0.12"]
 build-backend = "uv_build"
 
+[tool.uv]
+# Opt this repository out of any `exclude-newer` freshness filter. A relative
+# cutoff configured outside the repository (e.g. a developer's global
+# ~/.config/uv/uv.toml) is baked into uv.lock as `exclude-newer-span`, so it
+# silently re-resolves and downgrades dependencies on a bare `uv run` while
+# Renovate and CI, which see no such cutoff, lock the newest releases.
+# Declaring the setting here keeps resolution identical for developers, CI,
+# and Renovate.
+exclude-newer = false
+
 [tool.uv.build-backend]
 module-root = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,13 +73,6 @@ requires = ["uv_build>=0.5.0,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv]
-# Opt this repository out of any `exclude-newer` freshness filter. A relative
-# cutoff configured outside the repository (e.g. a developer's global
-# ~/.config/uv/uv.toml) is baked into uv.lock as `exclude-newer-span`, so it
-# silently re-resolves and downgrades dependencies on a bare `uv run` while
-# Renovate and CI, which see no such cutoff, lock the newest releases.
-# Declaring the setting here keeps resolution identical for developers, CI,
-# and Renovate.
 exclude-newer = false
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Three independent fixes that the lockfile maintenance PR (#373) currently trips over. Each is correct on `main` on its own merits, so they land here rather than inside a Renovate-owned branch that gets force-pushed.

### Pass a bytestring query string in the test request helper

`make_request` built an ASGI scope with a `str` `query_string`, which violates the spec. Starlette 1.0.0 decoded it only when non-empty, so the query-less call sites happened to work. Starlette 1.3.1, selected by lockfile maintenance, decodes unconditionally, and all 56 tests that reach the helper raise `AttributeError`.

The bug is latent on `main` today: any call site passing a path with a query string would already fail. Production code is unaffected — `_merge_parameter_strings` already returns bytes.

### Remove redundant casts flagged by ty

ty 0.0.63+ infers `get_resource_type()` as `str` and the collected search parameter entries as `dict[str, str]`, so both casts are redundant and the lint workflow fails on the diagnostics. Verified against both the pinned ty 0.0.32 and the newer versions Renovate selects.

### Opt out of exclude-newer freshness filters

A relative `exclude-newer` cutoff configured outside the repository, such as in a developer's global `~/.config/uv/uv.toml`, is baked into `uv.lock` as `exclude-newer-span`. A bare `uv run` then silently re-resolves and downgrades dependencies, while Renovate and CI, which see no such cutoff, lock the newest releases — so local runs disagree with CI about which versions are under test. This is how the ty and starlette failures above stayed hidden locally.

Declaring the setting in the repository keeps resolution identical for developers, CI, and Renovate. `uv.lock` is unchanged: `uv lock --check` passes against the committed lockfile.

### Verification

- `prek run --all-files` passes
- Full suite passes on all three sequences (STU3 160, R4B 160, R5 188) against the currently locked dependency set
- Only exercised on Python 3.10 locally; CI covers 3.10–3.14 and Windows

### Note on #373

`fhir-core` 1.1.10 fixed the `SLOTS` import that broke against `annotated-types` 0.8.0, so no dependency constraint is needed. Once this merges, #373 should rebase clean and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)