### PR TITLE
Fix bytes/str comparisons in the search POST middleware

### DIFF
--- a/fhirstarter/fhirstarter.py
+++ b/fhirstarter/fhirstarter.py
@@ -548,12 +548,19 @@ async def _transform_search_type_post_request(
         and request.headers.get("Content-Type") == "application/x-www-form-urlencoded"
     ):
         scope = request.scope
+
+        # Merge the parameter strings before rewriting the method, because the Accept header is
+        # only honored for POST requests, and the merge needs to see the original method in order
+        # to give the header precedence over the _format parameters.
+        query_string = await _merge_parameter_strings(request)
+
         scope["method"] = "GET"
         if scope["path"].endswith("/_search"):
             scope["path"] = scope["path"][:-8]
-        if scope["raw_path"][-8:] == "/_search":
+        # raw_path is bytes, unlike path
+        if scope["raw_path"].endswith(b"/_search"):
             scope["raw_path"] = scope["raw_path"][:-8]
-        scope["query_string"] = await _merge_parameter_strings(request)
+        scope["query_string"] = query_string
         scope["headers"] = [
             (name, value)
             for name, value in scope["headers"]
@@ -619,7 +626,7 @@ async def _merge_parameter_strings(request: Request) -> bytes:
 
     for query_string in (await request.body(), request.scope["query_string"]):
         for name, values in parse_qs(query_string).items():
-            if format_ and name == "_format":
+            if format_ and name == b"_format":
                 continue
             merged[name].extend(values)
 

--- a/fhirstarter/tests/test_interactions.py
+++ b/fhirstarter/tests/test_interactions.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from functools import partial
 from inspect import iscoroutinefunction
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from requests.models import Response
@@ -307,37 +307,100 @@ def test_no_body(
 
 
 @pytest.mark.parametrize(
-    argnames="search_type_func,search_type_func_kwargs",
+    argnames="search_type_func,search_type_func_kwargs,content_type",
     argvalues=[
         (
             lambda client: partial(client.get, "/Patient"),
             {"params": {"family": "Baggins"}},
+            "application/fhir+json",
+        ),
+        (
+            lambda client: partial(client.get, "/Patient"),
+            {
+                "params": {"family": "Baggins"},
+                "headers": {"Accept": "application/fhir+xml"},
+            },
+            # The Accept header is only honored for search interactions by POST
+            "application/fhir+json",
+        ),
+        (
+            lambda client: partial(client.get, "/Patient"),
+            {"params": {"family": "Baggins", "_format": "xml"}},
+            "application/fhir+xml",
+        ),
+        (
+            lambda client: partial(client.get, "/Patient"),
+            {
+                "params": {"family": "Baggins", "_format": "xml"},
+                "headers": {"Accept": "application/fhir+json"},
+            },
+            "application/fhir+xml",
         ),
         (
             lambda client: partial(client.post, "/Patient/_search"),
             {"data": {"family": "Baggins"}},
+            "application/fhir+json",
+        ),
+        (
+            lambda client: partial(client.post, "/Patient/_search"),
+            {
+                "data": {"family": "Baggins"},
+                "headers": {"Accept": "application/fhir+xml"},
+            },
+            "application/fhir+xml",
+        ),
+        (
+            lambda client: partial(client.post, "/Patient/_search"),
+            {"data": {"family": "Baggins", "_format": "xml"}},
+            "application/fhir+xml",
+        ),
+        (
+            lambda client: partial(client.post, "/Patient/_search"),
+            {
+                "data": {"family": "Baggins", "_format": "xml"},
+                "headers": {"Accept": "application/fhir+json"},
+            },
+            # For search interactions by POST, the Accept header supersedes _format
+            "application/fhir+json",
         ),
     ],
-    ids=["get", "post"],
+    ids=[
+        "get",
+        "get accept header",
+        "get format parameter",
+        "get accept header and format parameter",
+        "post",
+        "post accept header",
+        "post format parameter",
+        "post accept header and format parameter",
+    ],
 )
 def test_search_type(
     client: TestClient,
     patient_id: str,
     search_type_func: Callable[[TestClient], Callable[..., Response]],
-    search_type_func_kwargs: dict[str, str],
+    search_type_func_kwargs: dict[str, Any],
+    content_type: str,
 ) -> None:
-    """Test the FHIR search interaction."""
+    """Test the FHIR search interaction, including negotiation of the response format."""
     search_type_response = search_type_func(client)(**search_type_func_kwargs)
+
+    bundle = {
+        "resourceType": "Bundle",
+        "type": "searchset",
+        "total": 1,
+        "entry": [{"resource": resource(patient_id)}],
+    }
 
     assert_expected_response(
         search_type_response,
         status.HTTP_200_OK,
-        content={
-            "resourceType": "Bundle",
-            "type": "searchset",
-            "total": 1,
-            "entry": [{"resource": resource(patient_id)}],
-        },
+        content_type=content_type,
+        content=(
+            bundle
+            if content_type == "application/fhir+json"
+            else Bundle(**bundle).model_dump_xml()
+        ),
     )
 
 
@@ -462,5 +525,65 @@ def test_search_type_parameter_multiple_values(
             "resourceType": "Bundle",
             "type": "searchset",
             "total": 0,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="search_type_func,search_type_func_kwargs",
+    argvalues=[
+        (
+            lambda client: partial(client.get, "/Patient"),
+            {"params": {"family": "Baggins", "_format": "bogus"}},
+        ),
+        (
+            lambda client: partial(client.post, "/Patient/_search"),
+            {"data": {"family": "Baggins", "_format": "bogus"}},
+        ),
+    ],
+    ids=["get", "post"],
+)
+def test_search_type_invalid_format(
+    client: TestClient,
+    search_type_func: Callable[[TestClient], Callable[..., Response]],
+    search_type_func_kwargs: dict[str, Any],
+) -> None:
+    """Test the FHIR search interaction with an unrecognized _format parameter value."""
+    search_type_response = search_type_func(client)(**search_type_func_kwargs)
+
+    assert_expected_response(
+        search_type_response,
+        status.HTTP_400_BAD_REQUEST,
+        content=make_operation_outcome(
+            severity="error",
+            code="structure",
+            details_text="Invalid response format specified for '_format' parameter",
+        ).model_dump(),
+    )
+
+
+def test_search_type_post_accept_header_supersedes_invalid_format(
+    client: TestClient, patient_id: str
+) -> None:
+    """
+    Test the FHIR search interaction by POST with an Accept header and an invalid _format value.
+
+    The Accept header takes precedence, so the unrecognized _format value is discarded rather than
+    rejected.
+    """
+    search_type_response = client.post(
+        "/Patient/_search",
+        data={"family": "Baggins", "_format": "bogus"},
+        headers={"Accept": "application/fhir+json"},
+    )
+
+    assert_expected_response(
+        search_type_response,
+        status.HTTP_200_OK,
+        content={
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "total": 1,
+            "entry": [{"resource": resource(patient_id)}],
         },
     )


### PR DESCRIPTION
## Summary

Two branches in `_transform_search_type_post_request` / `_merge_parameter_strings` compared bytes
values taken from the ASGI scope against `str` literals, so neither ever fired:

- `scope["raw_path"][-8:] == "/_search"` — `raw_path` is bytes, so the suffix that the adjacent
  `scope["path"]` branch strips was left in place
- `name == "_format"` — `parse_qs` over a bytes query string yields bytes keys, so the `_format`
  de-duplication never ran

Fixing the second comparison alone changes nothing observable, because `scope["method"]` was
rewritten to `"GET"` *before* the parameter strings were merged, and
`FormatParameters.format_from_accept_header` only honors the `Accept` header for POST requests. So
`format_` was always `None` inside the merge and the de-duplication branch was doubly dead. All three
lines date from e8b2cf1 (2022), so this path has never worked.

The merge now runs before the method is rewritten, which is what makes the `Accept` header take
effect for search interactions by POST at all.

## Behavior change

Measured on `POST /Patient/_search`, before and after:

| request | before | after |
|---|---|---|
| `Accept: …+xml`, no `_format` | **200 json** — header ignored | 200 xml |
| `Accept: …+json`, body `_format=xml` | **200 xml** — body wins | 200 json |
| `Accept: …+json`, body `_format=bogus` | **400** OperationOutcome | 200 json |
| no `Accept`, no `_format` | 200 json | 200 json (unchanged) |
| no `Accept`, body `_format=xml` | 200 xml | 200 xml (unchanged) |
| `GET /Patient?_format=xml` | 200 xml | 200 xml (unchanged) |

Row 1 is the substantive one: a plain, spec-conformant search POST requesting XML via `Accept`, with
no `_format` anywhere, was silently answered with JSON. Content negotiation via `Accept` is the
primary mechanism in FHIR; `_format` exists for clients that cannot set headers. Row 2 is the
precedence that `FormatParameters.from_request` already documents for POST requests finally taking
effect.

Row 3 is a deliberate change of outcome: an unrecognized `_format` value alongside a valid `Accept`
header no longer produces a 400, because the parameter the server was told to ignore is discarded
during the merge. The old 400 happened for the wrong reason — the header was being ignored, so the
bogus value was the only input to format selection.

Existing tests all passed before this change because none of them sent an `Accept` header on a search
POST, and every `_format` test in the suite used GET.

## Tests

`test_search_type` gains the permutations of `Accept` header and `_format` parameter for both GET and
POST — eight rows, each asserting status code, response content type, and body:

| row | expected |
|---|---|
| `get` / `post` | json |
| `get accept header` | json — the header is not honored for GET |
| `post accept header` | xml |
| `get format parameter` / `post format parameter` | xml |
| `get accept header and format parameter` | xml — the parameter wins for GET |
| `post accept header and format parameter` | json — the header wins for POST |

The invalid-`_format` case became two named tests, since its outcome differs in kind:
`test_search_type_invalid_format` (GET and POST, both 400 with the `OperationOutcome`) and
`test_search_type_post_accept_header_supersedes_invalid_format` (200 with the Bundle). An
unrecognized `_format` value had no coverage at all before.

Coverage was verified by patching each defect back in and running the module:

| defect reintroduced | failures |
|---|---|
| `_format` key bytes/str | 4 — both `post accept header and format parameter` rows, both invalid-format-superseded rows |
| merge after method rewrite | 6 — the above plus both `post accept header` rows |
| `raw_path` bytes/str | **0** |

The `raw_path` fix is not covered: it isn't observable through the client, and nothing in FHIRStarter
or Starlette reads `raw_path` (in the installed stack only producers touch it — uvicorn, httpx's ASGI
transport, Starlette's `TestClient`). It matters to third-party ASGI middleware, instrumentation, or
application code that reconstructs a URL from `raw_path`, which would otherwise see
`/Patient/_search` while `path` says `/Patient`. The fix matches the obvious intent of the adjacent
line but addresses no observable scenario today.

## Verification

- `uv run --frozen pytest` across `FHIR_SEQUENCE={STU3,R4B,R5}` — 178 passed / 28 skipped, 178 / 28,
  and 206 passed respectively
- `prek`-managed hooks on commit: `ruff check`, `ruff format`, `ty` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
